### PR TITLE
Add Persian font and RTL theme

### DIFF
--- a/frontend/static/frontend/css/custom-rtl.css
+++ b/frontend/static/frontend/css/custom-rtl.css
@@ -1,1 +1,35 @@
-/* Add your RTL specific custom styles here */
+/* RTL specific custom styles */
+
+/* Persian font */
+body {
+    font-family: 'Vazirmatn', sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Vazirmatn', sans-serif;
+}
+
+/* Color theme overrides */
+:root {
+    --rtl-primary: #0f4c81;
+    --rtl-secondary: #f0f4f8;
+    --rtl-accent: #d62828;
+}
+
+.navbar.bg-primary {
+    background-color: var(--rtl-primary) !important;
+}
+
+body {
+    background-color: var(--rtl-secondary);
+}
+
+.btn-primary {
+    background-color: var(--rtl-primary);
+    border-color: var(--rtl-primary);
+}
+
+.alert-danger {
+    background-color: var(--rtl-accent);
+    border-color: var(--rtl-accent);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     {% if LANGUAGE_CODE == 'fa' %}
+        <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.rtl.min.css">
         <link rel="stylesheet" href="{% static 'frontend/css/custom-rtl.css' %}">
     {% endif %}


### PR DESCRIPTION
## Summary
- include Vazirmatn font for Persian interface
- style body and headings in custom-rtl.css
- add complementary colors for a distinct RTL theme

## Testing
- `python manage.py test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686fc81e4424832180dbd27b847b7534