### PR TITLE
Fix RTL custom CSS

### DIFF
--- a/frontend/static/frontend/css/custom-rtl.css
+++ b/frontend/static/frontend/css/custom-rtl.css
@@ -1,6 +1,4 @@
 /* RTL specific custom styles */
-
-codex/add-persian-web-font-and-styles
 /* Persian font */
 body {
     font-family: 'Vazirmatn', sans-serif;
@@ -33,7 +31,8 @@ body {
 .alert-danger {
     background-color: var(--rtl-accent);
     border-color: var(--rtl-accent);
-=======
+}
+
 /*
    All rules in this file are scoped to pages where the HTML
    element has dir="rtl". This avoids interfering with the
@@ -78,5 +77,4 @@ html[dir="rtl"] .alert {
 }
 html[dir="rtl"] .alert .btn-close {
     float: left;
-dev
 }


### PR DESCRIPTION
## Summary
- clean up malformed styles in `custom-rtl.css` for Persian pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd26b7b688321a5bc8dcaf5779c0b