### PR TITLE
Add basic user management UI

### DIFF
--- a/frontend/forms.py
+++ b/frontend/forms.py
@@ -4,6 +4,23 @@ from django.contrib.auth import get_user_model
 
 User = get_user_model()
 
+
+class UserForm(forms.ModelForm):
+    """Simple form for creating users including password handling."""
+
+    password = forms.CharField(widget=forms.PasswordInput)
+
+    class Meta:
+        model = User
+        fields = ["username", "password", "role"]
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.set_password(self.cleaned_data["password"])
+        if commit:
+            user.save()
+        return user
+
 class TradingAccountForm(forms.ModelForm):
     class Meta:
         model = TradingAccount

--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -6,8 +6,9 @@ from .views import (
     IncomeStatementView, DeleteTradingAccountView, CalculateUnrealizedPnLView, 
     TransferFundsView, CurrencyListView, CurrencyCreateView, CurrencyUpdateView, 
     CurrencyDeleteView, AssetListView, AssetCreateView, AssetUpdateView, AssetDeleteView,
-    ChartOfAccountListView, ChartOfAccountCreateView, ChartOfAccountUpdateView, 
-    ChartOfAccountDeleteView, BalanceSheetView, FundManagementView,OpenTradesListView,TrialBalanceView
+    ChartOfAccountListView, ChartOfAccountCreateView, ChartOfAccountUpdateView,
+    ChartOfAccountDeleteView, BalanceSheetView, FundManagementView,OpenTradesListView,TrialBalanceView,
+    UserListView, UserCreateView, UserDeleteView
 )
 
 urlpatterns = [
@@ -37,6 +38,9 @@ urlpatterns = [
     path('assets/add/', AssetCreateView.as_view(), name='asset_add'),
     path('assets/<int:pk>/edit/', AssetUpdateView.as_view(), name='asset_edit'),
     path('assets/<int:pk>/delete/', AssetDeleteView.as_view(), name='asset_delete'),
+    path('users/', UserListView.as_view(), name='user_list'),
+    path('users/add/', UserCreateView.as_view(), name='user_add'),
+    path('users/<int:pk>/delete/', UserDeleteView.as_view(), name='user_delete'),
     path('chart-of-accounts/list/', ChartOfAccountListView.as_view(), name='chartofaccount_list'),
     path('chart-of-accounts/add/', ChartOfAccountCreateView.as_view(), name='chartofaccount_add'),
     path('chart-of-accounts/<int:pk>/edit/', ChartOfAccountUpdateView.as_view(), name='chartofaccount_edit'),

--- a/templates/base.html
+++ b/templates/base.html
@@ -74,6 +74,7 @@
                             <li><a class="dropdown-item" href="{% url 'unrealized_pnl_view' %}"><i class="bi bi-calculator"></i> {% trans "Calculate Unrealized PnL" %}</a></li>
                             <li><a class="dropdown-item" href="{% url 'currency_list' %}"><i class="bi bi-cash-stack"></i> {% trans "Currencies" %}</a></li>
                             <li><a class="dropdown-item" href="{% url 'asset_list' %}"><i class="bi bi-archive-fill"></i> {% trans "Assets" %}</a></li>
+                            <li><a class="dropdown-item" href="{% url 'user_list' %}"><i class="bi bi-people-fill"></i> Users</a></li>
                         </ul>
                     </li>
                 </ul>

--- a/templates/user_confirm_delete.html
+++ b/templates/user_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Confirm Delete{% endblock %}
+{% block content %}
+<div class="container mt-4">
+    <div class="card border-danger">
+        <div class="card-header bg-danger text-white">
+            <h5 class="mb-0"><i class="bi bi-exclamation-triangle-fill"></i> Confirm Deletion</h5>
+        </div>
+        <div class="card-body">
+            <p class="card-text">Are you sure you want to delete the user: <strong>{{ object.username }}</strong>?</p>
+            <p class="text-danger">This action cannot be undone.</p>
+            <form method="post">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-danger"><i class="bi bi-trash-fill"></i> Yes, Delete</button>
+                <a href="{% url 'user_list' %}" class="btn btn-secondary"><i class="bi bi-x-circle"></i> Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/user_form.html
+++ b/templates/user_form.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block title %}Add User{% endblock %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Add User</h2>
+    <div class="card">
+        <div class="card-body">
+            <form method="post">
+                {% csrf_token %}
+                <div class="form-group">
+                    {{ form.username.label_tag }}
+                    {{ form.username }}
+                    {% if form.username.errors %}<div class="text-danger">{{ form.username.errors|first }}</div>{% endif %}
+                </div>
+                <div class="form-group">
+                    {{ form.password.label_tag }}
+                    {{ form.password }}
+                    {% if form.password.errors %}<div class="text-danger">{{ form.password.errors|first }}</div>{% endif %}
+                </div>
+                <div class="form-group">
+                    {{ form.role.label_tag }}
+                    {{ form.role }}
+                    {% if form.role.errors %}<div class="text-danger">{{ form.role.errors|first }}</div>{% endif %}
+                </div>
+                <button type="submit" class="btn btn-success">Create</button>
+                <a href="{% url 'user_list' %}" class="btn btn-secondary">Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/user_list.html
+++ b/templates/user_list.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block title %}Users{% endblock %}
+{% block content %}
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2><i class="bi bi-people-fill"></i> Users</h2>
+        <a href="{% url 'user_add' %}" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Add User</a>
+    </div>
+    <div class="card">
+        <div class="card-body">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>Username</th>
+                        <th>Role</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for user in users %}
+                    <tr>
+                        <td>{{ user.username }}</td>
+                        <td>{{ user.role }}</td>
+                        <td>
+                            <a href="{% url 'user_delete' user.pk %}" class="btn btn-sm btn-danger"><i class="bi bi-trash-fill"></i> Delete</a>
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="3" class="text-center">No users found.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `UserForm` for creating new users
- add `AdminRequiredMixin`
- implement list, add, and delete views for users
- expose user routes and link in navigation
- create templates for user management

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68721d7684b083219d3bdd85e13e53ce