### PR TITLE
Enhance closed trade form UI

### DIFF
--- a/staticfiles/frontend/css/custom.css
+++ b/staticfiles/frontend/css/custom.css
@@ -11,3 +11,7 @@ body {
 .card {
     margin-bottom: 1.5rem;
 }
+
+#optional-fields {
+    display: none;
+}

--- a/staticfiles/frontend/js/custom.js
+++ b/staticfiles/frontend/js/custom.js
@@ -1,6 +1,37 @@
 // Custom JS for Financial System
 
 document.addEventListener('DOMContentLoaded', function() {
-    console.log('Custom JS loaded successfully!');
-    // You can add interactive functionalities here.
+    var toggleBtn = document.getElementById('toggle-optional');
+    var optionalSection = document.getElementById('optional-fields');
+
+    if (toggleBtn && optionalSection) {
+        toggleBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            if (optionalSection.style.display === 'none' || optionalSection.style.display === '') {
+                optionalSection.style.display = 'block';
+                toggleBtn.textContent = toggleBtn.getAttribute('data-hide-text');
+            } else {
+                optionalSection.style.display = 'none';
+                toggleBtn.textContent = toggleBtn.getAttribute('data-show-text');
+            }
+        });
+    }
+
+    var form = document.getElementById('direct-trade-form');
+    if (form) {
+        form.addEventListener('submit', function() {
+            var grossField = document.getElementById('id_gross_profit_or_loss');
+            var gross = parseFloat(grossField ? grossField.value : 0);
+            ['broker', 'trader'].forEach(function(type) {
+                var checkbox = document.getElementById(type + '_commission_percent');
+                var field = document.getElementById('id_' + type + '_commission');
+                if (checkbox && checkbox.checked && field && !isNaN(gross)) {
+                    var percentVal = parseFloat(field.value);
+                    if (!isNaN(percentVal)) {
+                        field.value = (gross * percentVal / 100).toFixed(2);
+                    }
+                }
+            });
+        });
+    }
 });

--- a/templates/direct_add_trade.html
+++ b/templates/direct_add_trade.html
@@ -13,7 +13,7 @@
             <p class="card-text text-muted">{% trans "Use this form to record trades that have already been closed on another platform." %}</p>
             <hr>
 
-            <form method="post" novalidate>
+            <form method="post" id="direct-trade-form" novalidate>
                 {% csrf_token %}
 
                 {% if form.non_field_errors %}
@@ -93,28 +93,46 @@
                 </div>
 
                 <hr>
-                <h5>{% trans "Commission Details" %}</h5>
-                
-                <div class="row">
-                     <div class="col-md-4">
-                        <div class="form-group">
-                            {{ form.broker_commission.label_tag }}
-                            {{ form.broker_commission }}
-                            {% if form.broker_commission.errors %}<div class="invalid-feedback d-block">{{ form.broker_commission.errors|first }}</div>{% endif %}
+                <button id="toggle-optional" type="button" class="btn btn-outline-secondary mb-3" data-show-text="{% trans 'Show Optional Fields' %}" data-hide-text="{% trans 'Hide Optional Fields' %}">{% trans 'Show Optional Fields' %}</button>
+
+                <div id="optional-fields">
+                    <h5>{% trans "Commission Details" %}</h5>
+
+                    <div class="row">
+                         <div class="col-md-4">
+                            <div class="form-group">
+                                {{ form.broker_commission.label_tag }}
+                                <div class="input-group">
+                                    {{ form.broker_commission }}
+                                    <span class="input-group-text">
+                                        <input type="checkbox" id="broker_commission_percent" class="form-check-input me-1">
+                                        %
+                                    </span>
+                                </div>
+                                <small class="form-text text-muted">{% trans "Check to treat value as percent of Gross P/L" %}</small>
+                                {% if form.broker_commission.errors %}<div class="invalid-feedback d-block">{{ form.broker_commission.errors|first }}</div>{% endif %}
+                            </div>
                         </div>
-                    </div>
-                     <div class="col-md-4">
-                        <div class="form-group">
-                            {{ form.trader_commission.label_tag }}
-                            {{ form.trader_commission }}
-                            {% if form.trader_commission.errors %}<div class="invalid-feedback d-block">{{ form.trader_commission.errors|first }}</div>{% endif %}
+                         <div class="col-md-4">
+                            <div class="form-group">
+                                {{ form.trader_commission.label_tag }}
+                                <div class="input-group">
+                                    {{ form.trader_commission }}
+                                    <span class="input-group-text">
+                                        <input type="checkbox" id="trader_commission_percent" class="form-check-input me-1">
+                                        %
+                                    </span>
+                                </div>
+                                <small class="form-text text-muted">{% trans "Check to treat value as percent of Gross P/L" %}</small>
+                                {% if form.trader_commission.errors %}<div class="invalid-feedback d-block">{{ form.trader_commission.errors|first }}</div>{% endif %}
+                            </div>
                         </div>
-                    </div>
-                     <div class="col-md-4">
-                        <div class="form-group">
-                            {{ form.commission_recipient.label_tag }}
-                            {{ form.commission_recipient }}
-                            {% if form.commission_recipient.errors %}<div class="invalid-feedback d-block">{{ form.commission_recipient.errors|first }}</div>{% endif %}
+                         <div class="col-md-4">
+                            <div class="form-group">
+                                {{ form.commission_recipient.label_tag }}
+                                {{ form.commission_recipient }}
+                                {% if form.commission_recipient.errors %}<div class="invalid-feedback d-block">{{ form.commission_recipient.errors|first }}</div>{% endif %}
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- hide optional fields when recording closed trades
- allow commission fields to be specified as percentages of gross P/L
- toggle optional fields via button

## Testing
- `python manage.py test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687283395d5c8321b06aba05aabc2b3f